### PR TITLE
fix: remove duplicate env key in Railway deployment workflow

### DIFF
--- a/.github/workflows/deploy-railway.yml
+++ b/.github/workflows/deploy-railway.yml
@@ -95,6 +95,15 @@ jobs:
       - name: Set Railway Environment Variables
         env:
           RAILWAY_TOKEN: ${{ secrets.RAILWAY_TOKEN }}
+          MONGODB_URI: ${{ secrets.MONGODB_URI }}
+          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+          GOOGLE_API_KEY: ${{ secrets.GOOGLE_API_KEY }}
+          REDIS_URL: ${{ secrets.REDIS_URL }}
+          NEXT_PUBLIC_API_URL: ${{ secrets.NEXT_PUBLIC_API_URL }}
+          NEXT_PUBLIC_ENABLE_SEARCH: ${{ secrets.NEXT_PUBLIC_ENABLE_SEARCH || 'true' }}
+          NEXT_PUBLIC_ENABLE_GEOSPATIAL: ${{ secrets.NEXT_PUBLIC_ENABLE_GEOSPATIAL || 'true' }}
+          LOG_LEVEL: ${{ secrets.LOG_LEVEL || 'info' }}
+          RATE_LIMIT_RPM: ${{ secrets.RATE_LIMIT_RPM || '20' }}
         run: |
           set +x  # Disable command echoing for security
 
@@ -110,16 +119,6 @@ jobs:
           railway variables --set RATE_LIMIT_RPM="$RATE_LIMIT_RPM" --environment production
 
           echo "✅ Environment variables configured"
-        env:
-          MONGODB_URI: ${{ secrets.MONGODB_URI }}
-          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
-          GOOGLE_API_KEY: ${{ secrets.GOOGLE_API_KEY }}
-          REDIS_URL: ${{ secrets.REDIS_URL }}
-          NEXT_PUBLIC_API_URL: ${{ secrets.NEXT_PUBLIC_API_URL }}
-          NEXT_PUBLIC_ENABLE_SEARCH: ${{ secrets.NEXT_PUBLIC_ENABLE_SEARCH || 'true' }}
-          NEXT_PUBLIC_ENABLE_GEOSPATIAL: ${{ secrets.NEXT_PUBLIC_ENABLE_GEOSPATIAL || 'true' }}
-          LOG_LEVEL: ${{ secrets.LOG_LEVEL || 'info' }}
-          RATE_LIMIT_RPM: ${{ secrets.RATE_LIMIT_RPM || '20' }}
 
       - name: Deploy to Railway
         id: deploy


### PR DESCRIPTION
## Summary
- Fixed GitHub Actions workflow validation error caused by duplicate `env` key definition
- Merged both `env` blocks into a single declaration in the "Set Railway Environment Variables" step

## Problem
The workflow file had two `env` keys at the same level (lines 96 and 113), which is invalid YAML syntax and caused the workflow validation to fail with the error: `'env' is already defined`

## Solution
Consolidated all environment variables into a single `env` block at the beginning of the step, maintaining the same functionality while fixing the syntax error.

## Test plan
- [x] Verify workflow file syntax is valid
- [ ] Push to trigger the workflow and confirm it runs without validation errors
- [ ] Monitor deployment process to ensure environment variables are still properly set

🤖 Generated with [Claude Code](https://claude.com/claude-code)