### PR TITLE
fix: resolve TypeScript errors in search components

### DIFF
--- a/apps/web/lib/api-client.ts
+++ b/apps/web/lib/api-client.ts
@@ -1,8 +1,5 @@
 import type { Activity, Organization, SearchResponse } from '@action-atlas/types';
 
-// Re-export SearchResponse for use in hooks
-export type { SearchResponse };
-
 import { API_ROUTES } from './constants';
 
 /**

--- a/apps/web/lib/hooks/useInfiniteSearch.ts
+++ b/apps/web/lib/hooks/useInfiniteSearch.ts
@@ -2,7 +2,9 @@
 
 import { useInfiniteQuery } from '@tanstack/react-query';
 
-import { searchActivities, type SearchResponse, type SearchFilters } from '@/lib/api-client';
+import type { SearchResponse } from '@action-atlas/types';
+
+import { searchActivities, type SearchFilters } from '@/lib/api-client';
 
 import { useDebounce } from './useDebounce';
 
@@ -36,7 +38,10 @@ export function useInfiniteSearch({
     enabled: enabled && debouncedQuery.length >= 3, // Only search if query is 3+ chars
     initialPageParam: 0,
     getNextPageParam: (lastPage, allPages) => {
-      const loadedCount = allPages.reduce((sum, page) => sum + page.results.length, 0);
+      const loadedCount = allPages.reduce(
+        (sum, page) => sum + page.results.length,
+        0
+      );
       // Return next offset if there are more results
       return loadedCount < lastPage.total ? loadedCount : undefined;
     },


### PR DESCRIPTION
## Summary
- Import SearchResponse directly from @action-atlas/types in useInfiniteSearch hook
- Remove problematic re-export from api-client that caused TS2459 error in CI

## Problem
The GitHub Actions type-check was failing with these errors:
- `TS2459`: Module declares 'SearchResponse' locally, but it is not exported
- `TS2339`: Properties 'relevanceScore' and 'distance' do not exist

The issue was a re-export pattern that TypeScript couldn't resolve in CI (even though it worked locally).

## Solution
- Import `SearchResponse` directly from `@action-atlas/types` instead of re-exporting from api-client
- Removed the re-export statement that was causing the TS2459 error
- The `SearchResult` type already includes `relevanceScore` and `distance` properties

## Test plan
- [x] Verify type-check passes locally
- [ ] Verify GitHub Actions type-check passes in CI
- [ ] Verify Railway deployment proceeds successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)