### PR TITLE
Fix Railway deployment by commenting out unset REDIS_URL variable

### DIFF
--- a/.github/workflows/deploy-railway.yml
+++ b/.github/workflows/deploy-railway.yml
@@ -110,7 +110,7 @@ jobs:
           railway variables --set MONGODB_URI="$MONGODB_URI" --environment production --service="${{ secrets.RAILWAY_SERVICE_NAME }}"
           railway variables --set OPENAI_API_KEY="$OPENAI_API_KEY" --environment production --service="${{ secrets.RAILWAY_SERVICE_NAME }}"
           railway variables --set GOOGLE_API_KEY="$GOOGLE_API_KEY" --environment production --service="${{ secrets.RAILWAY_SERVICE_NAME }}"
-          railway variables --set REDIS_URL="$REDIS_URL" --environment production --service="${{ secrets.RAILWAY_SERVICE_NAME }}"
+          # railway variables --set REDIS_URL="$REDIS_URL" --environment production --service="${{ secrets.RAILWAY_SERVICE_NAME }}"
           railway variables --set NEXT_PUBLIC_API_URL="$NEXT_PUBLIC_API_URL" --environment production --service="${{ secrets.RAILWAY_SERVICE_NAME }}"
           railway variables --set NODE_ENV="production" --environment production --service="${{ secrets.RAILWAY_SERVICE_NAME }}"
           railway variables --set NEXT_PUBLIC_ENABLE_SEARCH="$NEXT_PUBLIC_ENABLE_SEARCH" --environment production --service="${{ secrets.RAILWAY_SERVICE_NAME }}"


### PR DESCRIPTION
Comment out the REDIS_URL railway variable setting in the deploy workflow to prevent errors when the secret is not configured in the repository. The REDIS_URL secret is not currently set, causing the deployment to fail.