### PR TITLE
Fix Railway restart policy configuration

### DIFF
--- a/railway.toml
+++ b/railway.toml
@@ -4,7 +4,7 @@ buildCommand = "pnpm install --frozen-lockfile && pnpm build --filter=web"
 
 [deploy]
 startCommand = "cd apps/web && pnpm start"
-restartPolicyType = "on-failure"
+restartPolicyType = "ON_FAILURE"
 restartPolicyMaxRetries = 3
 
 [env]


### PR DESCRIPTION
Fixes the Railway deployment error by correcting the restartPolicyType from 'on-failure' to 'ON_FAILURE' in railway.toml.

Railway requires restartPolicyType values to be uppercase with underscores. The previous value 'on-failure' was invalid, causing deployment failures.