### PR TITLE
Fix Railway deployment with standalone server start command

### DIFF
--- a/railway.toml
+++ b/railway.toml
@@ -3,7 +3,7 @@ builder = "nixpacks"
 buildCommand = "pnpm install --frozen-lockfile && pnpm build --filter=web"
 
 [deploy]
-startCommand = "cd apps/web && pnpm start"
+startCommand = "node apps/web/.next/standalone/server.js"
 restartPolicyType = "ON_FAILURE"
 restartPolicyMaxRetries = 3
 


### PR DESCRIPTION
## Summary
- Fixed Railway start command to use Node.js standalone server instead of `pnpm start`
- Resolves incompatibility with Next.js `output: 'standalone'` configuration
- Fixes CORS issue by ensuring API routes are served from the same domain as the frontend

## Problem
The deployment was showing a warning:
```
⚠ "next start" does not work with "output: standalone" configuration. 
Use "node .next/standalone/server.js" instead.
```

This was also contributing to CORS errors because the API wasn't being served correctly.

## Solution
Updated `railway.toml` to use the correct standalone server entry point:
```toml
startCommand = "node apps/web/.next/standalone/server.js"
```

## Test plan
- [ ] Deploy to Railway and verify no startup warnings
- [ ] Verify API endpoints are accessible at the same domain as frontend
- [ ] Test search functionality to ensure CORS errors are resolved
- [ ] Check deployment logs for successful startup

🤖 Generated with [Claude Code](https://claude.com/claude-code)