### PR TITLE
Revert standalone deployment configuration

### DIFF
--- a/apps/web/next.config.ts
+++ b/apps/web/next.config.ts
@@ -3,8 +3,6 @@ import type { NextConfig } from 'next';
 const nextConfig: NextConfig = {
   reactStrictMode: true,
   poweredByHeader: false,
-  // Standalone output for Railway deployment
-  output: 'standalone',
   transpilePackages: [
     '@action-atlas/types',
     '@action-atlas/database',
@@ -12,7 +10,6 @@ const nextConfig: NextConfig = {
   ],
   // Disable typed routes for now - experimental feature causing type issues
   // typedRoutes: true,
-  outputFileTracingRoot: '../..',
   images: {
     remotePatterns: [
       {

--- a/railway.toml
+++ b/railway.toml
@@ -3,7 +3,7 @@ builder = "nixpacks"
 buildCommand = "pnpm install --frozen-lockfile && pnpm build --filter=web"
 
 [deploy]
-startCommand = "node apps/web/.next/standalone/server.js"
+startCommand = "cd apps/web && pnpm start"
 restartPolicyType = "ON_FAILURE"
 restartPolicyMaxRetries = 3
 


### PR DESCRIPTION
## Summary
- Restored `railway.toml` startCommand to use `pnpm start` instead of the standalone server
- Removed Next.js `output: 'standalone'` configuration
- Removed `outputFileTracingRoot` setting

## Changes
This PR reverts the standalone deployment approach that was previously implemented. The application will now use the standard Next.js server started via pnpm.

### Files Modified
- `railway.toml`: Changed startCommand from `node apps/web/.next/standalone/server.js` to `cd apps/web && pnpm start`
- `apps/web/next.config.ts`: Removed standalone output configuration and outputFileTracingRoot

## Test plan
- [ ] Verify Railway deployment starts successfully with pnpm start command
- [ ] Confirm application runs correctly in production
- [ ] Check that all routes and API endpoints work as expected

🤖 Generated with [Claude Code](https://claude.com/claude-code)