### PR TITLE
fix: add cuid support for activity lookup operations

### DIFF
--- a/packages/database/src/operations/activities.ts
+++ b/packages/database/src/operations/activities.ts
@@ -40,7 +40,7 @@ export async function findActivityById(
 ): Promise<ActivityDocument | null> {
   const collection = activities();
 
-  // Try both MongoDB ObjectId and business activityId
+  // Try MongoDB ObjectId, business activityId, and cuid
   let filter: Filter<ActivityDocument>;
 
   if (ObjectId.isValid(id)) {
@@ -48,10 +48,16 @@ export async function findActivityById(
       $or: [
         { _id: new ObjectId(id) },
         { activityId: id },
+        { cuid: id },
       ],
     };
   } else {
-    filter = { activityId: id };
+    filter = {
+      $or: [
+        { activityId: id },
+        { cuid: id },
+      ],
+    };
   }
 
   return await collection.findOne(filter);
@@ -156,10 +162,16 @@ export async function updateActivity(
       $or: [
         { _id: new ObjectId(id) },
         { activityId: id },
+        { cuid: id },
       ],
     };
   } else {
-    filter = { activityId: id };
+    filter = {
+      $or: [
+        { activityId: id },
+        { cuid: id },
+      ],
+    };
   }
 
   const updateDoc: UpdateFilter<ActivityDocument> = {
@@ -191,11 +203,17 @@ export async function updateActivityEmbedding(
       $or: [
         { _id: new ObjectId(id) },
         { activityId: id },
+        { cuid: id },
       ],
     };
   } else {
-    // If not a valid ObjectId, assume it's activityId
-    filter = { activityId: id };
+    // If not a valid ObjectId, try activityId or cuid
+    filter = {
+      $or: [
+        { activityId: id },
+        { cuid: id },
+      ],
+    };
   }
 
   const updateDoc: UpdateFilter<ActivityDocument> = {
@@ -229,10 +247,16 @@ export async function deleteActivity(
       $or: [
         { _id: new ObjectId(id) },
         { activityId: id },
+        { cuid: id },
       ],
     };
   } else {
-    filter = { activityId: id };
+    filter = {
+      $or: [
+        { activityId: id },
+        { cuid: id },
+      ],
+    };
   }
 
   if (hard) {


### PR DESCRIPTION
## Summary

- Added `cuid` field support to all activity database operations
- Updated `findActivityById()` to search by `cuid` in addition to `activityId` and `_id`
- Updated `updateActivity()`, `updateActivityEmbedding()`, and `deleteActivity()` to support `cuid` lookups
- Fixes issue where clicking on activity cards failed to load activity detail pages when using `cuid` as the business identifier

## Test plan

- [ ] Verify activity cards navigate successfully to activity detail pages
- [ ] Test that activity lookup works with `cuid` values
- [ ] Verify backward compatibility with `activityId` and `_id` lookups
- [ ] Test update and delete operations with `cuid` identifiers

🤖 Generated with [Claude Code](https://claude.com/claude-code)