### PR TITLE
fix: handle empty geolocations array in migration script

### DIFF
--- a/scripts/migrate-legacy-data-lib.ts
+++ b/scripts/migrate-legacy-data-lib.ts
@@ -102,12 +102,24 @@ export function transformDocument(doc: LegacyDocument, cleanup: boolean): Transf
           coordinates: coords,
         },
       };
-
-      if (cleanup) {
-        fieldsToUnset.push('geolocations');
-      }
     } else {
+      // geolocations array is empty - set a default location
       errors.push('geolocations array is empty');
+      updates.location = {
+        address: {
+          city: 'Unknown',
+          country: 'Unknown',
+        },
+        coordinates: {
+          type: 'Point',
+          coordinates: [0, 0],
+        },
+      };
+    }
+
+    // Always cleanup geolocations when transforming
+    if (cleanup) {
+      fieldsToUnset.push('geolocations');
     }
   }
 


### PR DESCRIPTION
## Summary
- Fix infinite migration loop for documents with empty `geolocations` arrays
- Now sets a default `location` object when `geolocations` is empty
- Properly removes `geolocations` field during cleanup regardless of whether it was empty or not

## Test plan
- [ ] Run `pnpm migrate-data` (dry run) and verify documents with empty geolocations show they will be migrated
- [ ] Run `pnpm migrate-data --execute --cleanup` and verify documents are migrated
- [ ] Run migration again and verify no documents need migration (no infinite loop)

🤖 Generated with [Claude Code](https://claude.com/claude-code)