### PR TITLE
fix: use muted badge variant for category labels

### DIFF
--- a/apps/web/components/ui/badge.tsx
+++ b/apps/web/components/ui/badge.tsx
@@ -25,7 +25,7 @@ const badgeVariants = cva(
         ghost:
           'border-transparent bg-zinc-100 text-zinc-700 hover:bg-zinc-200 focus:ring-zinc-400',
         muted:
-          'border border-zinc-200 bg-zinc-100 text-zinc-600 hover:bg-zinc-150 focus:ring-zinc-300',
+          'border border-zinc-200 bg-zinc-100 text-zinc-600 cursor-default',
         subtle:
           'border border-teal-200 bg-teal-50 text-teal-700 hover:bg-teal-100 focus:ring-teal-300',
       },


### PR DESCRIPTION
## Summary
- Make the `muted` badge variant non-clickable by adding `cursor-default` and removing hover effects
- Category badges in ActivityCard already use this variant

## Change
The `muted` badge variant now has `cursor-default` to indicate it's not interactive, fixing the UX issue where users thought category badges were clickable.

## Test plan
- [ ] Verify category badges show `cursor-default` on hover
- [ ] Ensure badges don't have hover state changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)