### PR TITLE
feat: add source tracking field to Activity schema

### DIFF
--- a/packages/database/src/schemas/activity.ts
+++ b/packages/database/src/schemas/activity.ts
@@ -31,4 +31,11 @@ export const activityIndexes = [
     key: { createdAt: -1 },
     name: 'created_date',
   },
+  // Unique index for external source deduplication (upsert by provider + externalId)
+  {
+    key: { 'source.provider': 1, 'source.externalId': 1 },
+    name: 'source_provider_externalId',
+    unique: true,
+    sparse: true, // Only index documents that have the source field
+  },
 ] as const;

--- a/packages/types/src/domain/activity.ts
+++ b/packages/types/src/domain/activity.ts
@@ -48,6 +48,19 @@ export const Contact = z.object({
 export type Contact = z.infer<typeof Contact>;
 
 /**
+ * Source tracking for activities imported from external APIs
+ * Used for deduplication during sync and attribution
+ */
+export const ActivitySource = z.object({
+  provider: z.string(),           // "api-engagement-france", "volunteer-match", etc.
+  externalId: z.string(),         // Original ID from the source API
+  lastSyncedAt: z.date(),         // When this activity was last synced
+  sourceUrl: z.string().optional(), // Link to original posting (for reference)
+});
+
+export type ActivitySource = z.infer<typeof ActivitySource>;
+
+/**
  * Activity schema - aligned with actual MongoDB document structure
  *
  * Embeddable fields (used for vector search embeddings):
@@ -98,6 +111,9 @@ export const Activity = z.object({
   happening: z.string().optional(),
   estimatedTime: z.string().optional(),
   typeOfGood: z.string().optional(),
+
+  // External source tracking (for imported activities)
+  source: ActivitySource.optional(),
 
   // Embedding fields
   embedding: z.array(z.number()).optional(),


### PR DESCRIPTION
## Summary

- Add optional `source` field to Activity Zod schema for tracking external API imports
- Add unique sparse index on `source.provider` + `source.externalId` for deduplication
- Enables upsert operations during sync from external APIs

## Changes

### `packages/types/src/domain/activity.ts`
- Add `ActivitySource` Zod schema with fields: `provider`, `externalId`, `lastSyncedAt`, `sourceUrl`
- Add optional `source` field to `Activity` schema

### `packages/database/src/schemas/activity.ts`
- Add unique sparse compound index on `source.provider` and `source.externalId`

## Test plan

- [x] TypeScript type-check passes
- [x] Existing tests pass
- [x] Field is optional (existing activities unaffected)
- [x] Field validates correctly with Zod

Closes #41

🤖 Generated with [Claude Code](https://claude.com/claude-code)