### PR TITLE
feat(types): add source tracking field to Activity schema

### DIFF
--- a/packages/types/src/domain/activity.ts
+++ b/packages/types/src/domain/activity.ts
@@ -48,6 +48,19 @@ export const Contact = z.object({
 export type Contact = z.infer<typeof Contact>;
 
 /**
+ * Source tracking for imported activities
+ * Used for deduplication and sync with external APIs
+ */
+export const Source = z.object({
+  provider: z.string(), // "montgomery-county", "nyc-opendata", etc.
+  externalId: z.string(), // Original ID from the source API
+  lastSyncedAt: z.date(), // When this activity was last synced
+  sourceUrl: z.string().url().optional(), // Link to original posting
+});
+
+export type Source = z.infer<typeof Source>;
+
+/**
  * Activity schema - aligned with actual MongoDB document structure
  *
  * Embeddable fields (used for vector search embeddings):
@@ -98,6 +111,9 @@ export const Activity = z.object({
   happening: z.string().optional(),
   estimatedTime: z.string().optional(),
   typeOfGood: z.string().optional(),
+
+  // Source tracking for imported activities
+  source: Source.optional(),
 
   // Embedding fields
   embedding: z.array(z.number()).optional(),


### PR DESCRIPTION
## Summary
- Add `Source` schema to track imported activities from external APIs
- Add optional `source` field to Activity schema
- Enables deduplication, sync tracking, and attribution for imported data

## Changes
Added to `packages/types/src/domain/activity.ts`:

1. **Source schema** (lines 50-61):
   - `provider`: string - identifies the source API (e.g., "montgomery-county", "nyc-opendata")
   - `externalId`: string - original ID from the source API for deduplication
   - `lastSyncedAt`: date - timestamp of when this activity was last synced
   - `sourceUrl`: optional URL - link to original posting

2. **Activity schema enhancement**:
   - Added optional `source` field to Activity schema (line 116)

## Purpose
This change supports importing activities from external APIs by providing:
- Deduplication during sync (upsert by external ID)
- Tracking which activities to update vs create
- Attribution to source and debugging capabilities
- Link back to original posting

## Acceptance Criteria
- [x] Source schema defined with required fields (provider, externalId, lastSyncedAt)
- [x] sourceUrl is optional
- [x] source field added to Activity schema as optional
- [x] TypeScript types exported correctly
- [x] Code builds without errors

## Test Plan
- [x] Verify TypeScript compilation succeeds
- [x] Run existing tests to ensure no regressions
- [ ] Test with real external API data in follow-up implementation
- [ ] Validate schema with sample source data

Closes #50

🤖 Generated with [Claude Code](https://claude.com/claude-code)